### PR TITLE
chore: add LICENSE and crates.io metadata for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.2.0"
 edition = "2021"
 description = "A clipboard history manager for Linux — Maccy-style, built with GTK4."
 license = "MIT"
+authors = ["tranhuuhuy297 <tranhuuhuy297@gmail.com>"]
+repository = "https://github.com/tranhuuhuy297/cliccy"
+homepage = "https://github.com/tranhuuhuy297/cliccy"
+readme = "README.md"
+keywords = ["clipboard", "gtk4", "wayland", "maccy", "linux"]
+categories = ["command-line-utilities", "gui"]
+exclude = ["target", "*.gif", "*.png", "*.mp4"]
 
 [[bin]]
 name = "cliccy"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tranhuuhuy297
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 A lightweight clipboard history manager for Linux — a Maccy-style popup, built
 with **Rust + GTK4**. Works on X11 and Wayland (tested: Ubuntu 22.04+).
 
+## Demo
+
+<!-- Record a 5–10s clip (hotkey → type-to-search → ↑/↓ → Ctrl+P pin → Enter
+     paste) and drop it in docs/. A static screenshot of the open popup makes a
+     good fallback. -->
+![Cliccy demo](docs/cliccy-demo.gif)
+
 ## Features
 
 - Resident daemon that records what you copy — text **and PNG images**


### PR DESCRIPTION
- Add MIT LICENSE file (referenced by Cargo.toml and README)
- Add repository, homepage, keywords, categories, authors to Cargo.toml
- Add demo section placeholder to README